### PR TITLE
Fix: small typo in sendmail.go

### DIFF
--- a/sendmail.go
+++ b/sendmail.go
@@ -78,7 +78,7 @@ func (m *SendMailRequest) Execute() error {
 
 	// TLS config
 	tlsconfig := &tls.Config{
-		InsecureSkipVerify: viper.GetBool("SMTP_VERITY_CERT"),
+		InsecureSkipVerify: viper.GetBool("SMTP_SKIP_VERIFY_CERT"),
 		ServerName:         smtpServerHost,
 	}
 


### PR DESCRIPTION
Hey guys, great job! I found a small type in the environment variable `SMTP_VERITY_CERT`. Additionally, I would suggest to rename the variable to `SMTP_SKIP_VERIFY_CERT` because the action in `tlsconfig` can be more clearly understood, I think. What so you mean?